### PR TITLE
Define zend_extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,7 @@ RUN cd idnkit && \
     echo "extension=idnkit.so" >> /usr/local/lib/php.ini
 
 ### Install xdebug
-RUN pecl install xdebug && echo 'extension=xdebug.so' >> /usr/local/lib/php.ini
+RUN pecl install xdebug && echo 'zend_extension=xdebug.so' >> /usr/local/lib/php.ini
 
 ### Ruby
 


### PR DESCRIPTION
`PHP Warning: Xdebug MUST be loaded as a Zend extension in Unknown on line 0` occur.
`extension=xdebug.so` is wrong.
Correctly is `zend_extension=xdebug.so`.
